### PR TITLE
Add env example and upload target

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+# Example environment configuration for direnv
+export BOT_TOKEN="your-telegram-token"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# environment files
+.env
+.envrc
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Data files
+cs2_teammates.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+IMAGE=cs2-bot
+TAG=latest
+SERVER=erik@165.227.148.29
+SERVER_DIR=/home/erik/cs2-bot
+
+.PHONY: test build upload deploy clean
+
+test:
+	python -m py_compile player_finder.py
+
+build:
+	IMG=$(IMAGE) TAG=$(TAG) docker compose -f docker/build.yml build
+
+upload:
+	rsync -av --exclude '.git' --exclude '__pycache__' ./ $(SERVER):$(SERVER_DIR)
+
+deploy: build upload
+	ssh $(SERVER) "cd $(SERVER_DIR) && IMG=$(IMAGE) TAG=$(TAG) BOT_TOKEN=$(BOT_TOKEN) docker stack deploy -c docker/run.yml cs2bot"
+
+clean:
+	docker system prune -f

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+# Erik Petrosyan ©
+FROM python:3.11-slim AS main
+
+LABEL version="1.0"
+LABEL author="ERIK_PETROSYAN"
+LABEL description="CS2 teammate finder bot"
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --disabled-password --gecos "" erik && chown -R erik /app
+USER erik
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --chown=erik:erik . .
+
+CMD ["python", "player_finder.py"]
+
+EXPOSE 2222

--- a/docker/build.yml
+++ b/docker/build.yml
@@ -1,0 +1,11 @@
+# Erik Petrosyan ©
+version: '3.8'
+
+services:
+    cs2-bot:
+        container_name: ${IMG}
+        build:
+            context: ../
+            dockerfile: ./docker/Dockerfile
+            target: main
+        image: ${IMG}:${TAG}

--- a/docker/run.yml
+++ b/docker/run.yml
@@ -1,0 +1,18 @@
+# Erik Petrosyan ©
+version: '3.8'
+
+services:
+    cs2-bot:
+        image: ${IMG}:${TAG}
+        user: erik:erik
+        deploy:
+            replicas: 1
+        environment:
+            - BOT_TOKEN=${BOT_TOKEN}
+        networks:
+            - internal_net
+        command: python player_finder.py
+
+networks:
+    internal_net:
+        driver: overlay

--- a/player_finder.py
+++ b/player_finder.py
@@ -5,6 +5,7 @@ import random
 import logging
 from datetime import datetime, timedelta
 import asyncio
+import os
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardMarkup, KeyboardButton
 from telegram.ext import (
     Application, CommandHandler, MessageHandler,
@@ -210,7 +211,11 @@ async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 # ----- Main App -----
 def main():
-    app = Application.builder().token("7628113009:AAF5qeGTzcRfCCuPbkmBdKOV_utO6a81-h8").build()
+    token = os.environ.get("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN environment variable not set")
+
+    app = Application.builder().token(token).build()
 
     conv = ConversationHandler(
         entry_points=[CommandHandler("start", start)],


### PR DESCRIPTION
## Summary
- add `.envrc.example` for direnv usage
- ignore local env files and caches
- support uploading to remote server in Makefile

## Testing
- `python -m py_compile player_finder.py`
- `docker compose -f docker/build.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685814afa75483278c0594f0d2450a64